### PR TITLE
Remove version constraint from fourseven:scss

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.3');
-  api.use('fourseven:scss@1.0.0');
+  api.use('fourseven:scss');
   api.addFiles([
     // Helpers
     "neat/_neat-helpers.scss",


### PR DESCRIPTION
Tested by creating a local package and adding successfully.

fixes #2